### PR TITLE
Remove below dirs from `dir` section of RPM spec file.

### DIFF
--- a/scripts/blackbird-memcached.spec
+++ b/scripts/blackbird-memcached.spec
@@ -49,9 +49,7 @@ rm -rf $RPM_BUILD_ROOT
 
 %files -f INSTALLED_FILES
 %defattr(-,root,root)
-%dir %{include_dir}
 %config(noreplace) %{include_dir}/memcached.cfg
-%dir %{plugins_dir}
 %{plugins_dir}/memcached.*
 
 %changelog


### PR DESCRIPTION
We'll install blackbird-memcached.
And following error occurred...

```
Transaction check error:
  ファイル /etc/blackbird/conf.d (パッケージ blackbird-memcached-0.1.4-1.el6.noarch から) は、パッケージ blackbird-0.4.1-1.el6.noarch からのファイルと競合しています。
  ファイル /opt/blackbird/plugins (パッケージ blackbird-memcached-0.1.4-1.el6.noarch から) は、パッケージ blackbird-0.4.1-1.el6.noarch からのファイルと競合しています。
```

So, we think `/etc/blackbird/conf.d` and `/opt/blackbird/plugins` directories are removed from `%files` section.
